### PR TITLE
set to use a specific coredns version instead of HEAD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.12-stretch
 
 RUN apt update && apt upgrade -y && apt install iptables -y
 
-RUN git clone https://github.com/coredns/coredns.git /coredns
+RUN git clone --single-branch --branch v1.5.2 https://github.com/coredns/coredns.git /coredns
 
 WORKDIR /coredns
 


### PR DESCRIPTION
* changes the dockerfile to use a specific version of coredns
* set to using 1.5.2 now