### PR TITLE
coredns version update: use latest and greatest 1.6.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,21 @@ jobs:
     steps:
       - checkout
       - run: make build
+      - run:
+          name: Archive Docker image
+          command: docker save -o image.tar contentful-labs/coredns-nodecache
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./image.tar
   publish-branch:
     executor: docker-publisher
     steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Load archived Docker image
+          command: docker load -i /tmp/workspace/image.tar
       - run:
           name: publish docker image with branch
           command: |
@@ -29,6 +41,11 @@ jobs:
   publish-master:
     executor: docker-publisher
     steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Load archived Docker image
+          command: docker load -i /tmp/workspace/image.tar
       - run:
           name: publish docker image with latest tag 
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.12-stretch AS builder
 
 RUN apt update && apt upgrade -y && apt install iptables -y
 
-RUN git clone --single-branch --branch v1.5.2 https://github.com/coredns/coredns.git /coredns
+RUN git clone --single-branch --branch v1.6.2 https://github.com/coredns/coredns.git /coredns
 
 WORKDIR /coredns
 


### PR DESCRIPTION
changes since 1.5.2:

* https://coredns.io/2019/07/28/coredns-1.6.0-release/
* https://coredns.io/2019/08/02/coredns-1.6.1-release/
* https://coredns.io/2019/08/13/coredns-1.6.2-release/

Also fixes circleci job based on info from https://circleci.com/blog/using-circleci-workflows-to-replicate-docker-hub-automated-builds/