### PR TITLE
add an option to not remove network interface and iptables on shutdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.12-stretch AS builder
 
 RUN apt update && apt upgrade -y && apt install iptables -y
 
-RUN git clone --single-branch --branch v1.6.2 https://github.com/coredns/coredns.git /coredns
+RUN git clone --single-branch --branch v1.6.3 https://github.com/coredns/coredns.git /coredns
 
 WORKDIR /coredns
 
@@ -12,7 +12,6 @@ RUN make
 RUN mkdir -p plugin/nodecache
 RUN echo 'nodecache:nodecache' >> /coredns/plugin.cfg
 
-COPY Corefile /coredns/Corefile
 COPY *.go /coredns/plugin/nodecache/
 RUN make
 RUN chmod 0755 /coredns/coredns
@@ -21,7 +20,7 @@ FROM alpine:latest
 RUN apk add iptables
 
 COPY --from=builder /coredns/coredns /
-COPY --from=builder /coredns/Corefile /
+COPY Corefile /
 
 EXPOSE 5300
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ for this are:
 
 You can use the docker hub image available at https://hub.docker.com/r/contentful/coredns-nodecache
 
-Configuration is done by adding "nodecache" to configuration blocks in your CoreDNS configuration file.
+Configuration is done by adding `nodecache` to configuration blocks in your CoreDNS configuration file.
+
+```
+nodecache [skipteardown]
+```
+
+* **skipteardown**: skips removing the iptables and dummy network interface on shutdown
 
 As the following example shows, you can use the directive in several blocks. For each block, coredns-nodecache will
 add the "bind" address to the dummy interface, and create iptable rules for the IP:PORT.


### PR DESCRIPTION
adds `skipTeardown` option that skips removing ptables and dummy interface on shutdown

This is useful while running 2 daemonsets (for HA) that listen on the same interface's ip:port.

also upgrade to coredns 1.6.3. https://coredns.io/2019/08/31/coredns-1.6.3-release/