### PR TITLE
Do not try & fail to push an image for PRs from forked repos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,9 @@ workflows:
             - test
           filters:
             branches:
-              ignore: master
+              ignore:
+                - master
+                - /pull\/[0-9]+/
       - publish-master:
           requires:
             - build


### PR DESCRIPTION
PRs from forked repos will not have the credentials to push to the Docker Registry - so skip this step.