### PR TITLE
fix manifest: secondary: Corefile ports incorrect

### DIFF
--- a/k8s/node-local-ha.yaml
+++ b/k8s/node-local-ha.yaml
@@ -1,5 +1,13 @@
 ---
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coredns-nodecache
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: coredns-nodecache-primary
@@ -15,7 +23,7 @@ data:
         }
         reload
         loop
-        bind 169.254.20.10 # Arbitrary, dummy IP
+        bind 169.254.20.10 # Set your cluster dns to this
         nodecache skipteardown
         template IN AAAA {
           rcode NOERROR
@@ -23,8 +31,8 @@ data:
         forward . 100.64.0.10 { # Kube-DNS IP
           force_tcp
         }
-        prometheus :9254
-        health 169.254.20.10:8082
+        prometheus :9253
+        health 169.254.20.10:8080
         }
     in-addr.arpa:53 {
         errors
@@ -39,7 +47,7 @@ data:
         forward . /etc/resolv.conf {
           force_tcp
         }
-        prometheus :9254
+        prometheus :9253
         }
     .:53 {
         errors
@@ -56,7 +64,7 @@ data:
         forward . /etc/resolv.conf {
           force_tcp
         }
-        prometheus :9254
+        prometheus :9253
         }
 ---
 apiVersion: apps/v1
@@ -153,11 +161,11 @@ data:
         }
         reload
         loop
-        bind 169.254.20.10 # Arbitrary, dummy IP
+        bind 169.254.20.10 # Set your cluster dns to this
         template IN AAAA {
           rcode NOERROR
         }
-        forward . 100.64.0.10 {  # Kube-DNS IP
+        forward . 100.64.0.10 { # Kube-DNS IP
           force_tcp
         }
         prometheus :9254
@@ -238,20 +246,14 @@ spec:
         securityContext:
           privileged: true
         ports:
-        - containerPort: 53
-          name: dns
-          protocol: UDP
-        - containerPort: 53
-          name: dns-tcp
-          protocol: TCP
-        - containerPort: 9253
+        - containerPort: 9254
           name: metrics
           protocol: TCP
         livenessProbe:
           httpGet:
             host: 169.254.20.10
             path: /health
-            port: 8080
+            port: 8082
           initialDelaySeconds: 60
           timeoutSeconds: 5
         volumeMounts:


### PR DESCRIPTION
the manifest had the wrong ports defined for prometheus and health checks. 
Also adds a service account. 