### PR TITLE
Add support for linux/arm64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,25 +23,35 @@ jobs:
       - checkout
       - run: make build
       - run:
-          name: Archive Docker image
-          command: docker save -o image.tar contentful-labs/coredns-nodecache
+          name: Archive Docker images
+          command: |
+            docker save -o image-amd64.tar contentful-labs/coredns-nodecache-amd64
+            docker save -o image-arm64.tar contentful-labs/coredns-nodecache-arm64
       - persist_to_workspace:
           root: .
           paths:
-            - ./image.tar
+            - ./image-amd64.tar
+            - ./image-arm64.tar
   publish-branch:
     executor: docker-publisher
     steps:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          name: Load archived Docker image
-          command: docker load -i /tmp/workspace/image.tar
-      - run:
-          name: publish docker image with branch
+          name: Load archived Docker images
           command: |
-            docker tag contentful-labs/coredns-nodecache:latest $IMAGE_NAME:$CIRCLE_BRANCH
+            docker load -i /tmp/workspace/image-amd64.tar
+            docker load -i /tmp/workspace/image-arm64.tar
+      - run:
+          name: publish docker images with branch
+          command: |
+            docker tag contentful-labs/coredns-nodecache-amd64:latest $IMAGE_NAME:$CIRCLE_BRANCH-amd64
+            docker tag contentful-labs/coredns-nodecache-arm64:latest $IMAGE_NAME:$CIRCLE_BRANCH-arm64
             echo "$docker_password" | docker login -u "$docker_login" --password-stdin
+            docker push $IMAGE_NAME:$CIRCLE_BRANCH-amd64
+            docker push $IMAGE_NAME:$CIRCLE_BRANCH-arm64
+            docker manifest create $IMAGE_NAME:$CIRCLE_BRANCH $IMAGE_NAME:$CIRCLE_BRANCH-amd64 $IMAGE_NAME:$CIRCLE_BRANCH-arm64
+            docker manifest annotate --arch arm64 $IMAGE_NAME:$CIRCLE_BRANCH $IMAGE_NAME:$CIRCLE_BRANCH-arm64
             docker push $IMAGE_NAME:$CIRCLE_BRANCH
   publish-tag:
     executor: docker-publisher
@@ -52,10 +62,15 @@ jobs:
           name: Load archived Docker image
           command: docker load -i /tmp/workspace/image.tar
       - run:
-          name: publish docker image with tag
+          name: publish docker images with tag
           command: |
-            docker tag contentful-labs/coredns-nodecache:latest $IMAGE_NAME:$CIRCLE_TAG
+            docker tag contentful-labs/coredns-nodecache-amd64:latest $IMAGE_NAME:$CIRCLE_TAG-amd64
+            docker tag contentful-labs/coredns-nodecache-arm64:latest $IMAGE_NAME:$CIRCLE_TAG-arm64
             echo "$docker_password" | docker login -u "$docker_login" --password-stdin
+            docker push $IMAGE_NAME:$CIRCLE_TAG-amd64
+            docker push $IMAGE_NAME:$CIRCLE_TAG-arm64
+            docker manifest create $IMAGE_NAME:$CIRCLE_TAG $IMAGE_NAME:$CIRCLE_TAG-amd64 $IMAGE_NAME:$CIRCLE_TAG-arm64
+            docker manifest annotate --arch arm64 $IMAGE_NAME:$CIRCLE_TAG $IMAGE_NAME:$CIRCLE_TAG-arm64
             docker push $IMAGE_NAME:$CIRCLE_TAG
   publish-master:
     executor: docker-publisher
@@ -64,12 +79,19 @@ jobs:
           at: /tmp/workspace
       - run:
           name: Load archived Docker image
-          command: docker load -i /tmp/workspace/image.tar
-      - run:
-          name: publish docker image with latest tag
           command: |
-            docker tag contentful-labs/coredns-nodecache:latest $IMAGE_NAME:latest
+            docker load -i /tmp/workspace/image-amd64.tar
+            docker load -i /tmp/workspace/image-arm64.tar
+      - run:
+          name: publish docker images with 'latest' tag
+          command: |
+            docker tag contentful-labs/coredns-nodecache-amd64:latest $IMAGE_NAME:latest-amd64
+            docker tag contentful-labs/coredns-nodecache-arm64:latest $IMAGE_NAME:latest-arm64
             echo "$docker_password" | docker login -u "$docker_login" --password-stdin
+            docker push $IMAGE_NAME:latest-amd64
+            docker push $IMAGE_NAME:latest-arm64
+            docker manifest create $IMAGE_NAME:latest $IMAGE_NAME:latest-amd64 $IMAGE_NAME:latest-arm64
+            docker manifest annotate --arch arm64 $IMAGE_NAME:latest $IMAGE_NAME:latest-arm64
             docker push $IMAGE_NAME:latest
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 build:
-	docker build -t contentful-labs/coredns-nodecache .
+	docker buildx build --platform linux/amd64 -t contentful-labs/coredns-nodecache-amd64 .
+	docker buildx build --platform linux/arm64 -t contentful-labs/coredns-nodecache-arm64 .
+	docker tag contentful-labs/coredns-nodecache-amd64 contentful-labs/coredns-nodecache
 
 run: build
 	docker run --cap-add=NET_ADMIN --cap-add=NET_RAW --privileged -P contentful-labs/coredns-nodecache


### PR DESCRIPTION
This patch updates the `Makefile` to build a `linux/amd64` and `linux/arm64` image and tag the `linux/amd64` image with the current name. 

The `.circleci` build script has been updated to create a docker multi-architecture manifest. The images need to get pushed before the manifest can be created. 